### PR TITLE
Custom level mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,12 +15,15 @@ https://wolfesoftware.com/loops/
 
 #### 1.5.0
 
-* Swap levels 16-21 with 22-27 to introduce toroidal topology before cement mode.
+* Swap levels 16-21 with 22-27 to introduce toroidal topology before locking tiles.
+    * If your current level was in this range, you'll be reset back to level 16.
 * Custom level mode available in the sidebar.
-    * Allows you to turn off cement mode.
+    * Allows you to turn off locking tiles.
     * Allows extreme sized levels.
-    * Allows toroidal topology without a starter island.
-    * Does not allow toroidal topology with odd sizes.
+    * Allows toroidal topology without a starter island (hard mode!).
+    * (Does not allow toroidal topology with odd sizes. It's complicated.)
+    * Settings are unlocked as you encounter them in the linear level progression.
+    * Resume linear levels by collapsing the `Custom Level` settings.
 * Level select available in the side bar to revisit previous levels.
 
 #### 1.4.0
@@ -75,6 +78,8 @@ https://wolfesoftware.com/loops/
  * Toroidal topoly (loops left/right and up/down)
  * Island of locked tiles in the middle of toroidal levels
  * "Smell the roses" after completing a level before the transition to the next level
+
+Project first started 2018-Aug-24.
 
 ## Development
 

--- a/README.md
+++ b/README.md
@@ -13,6 +13,16 @@ https://wolfesoftware.com/loops/
 
 ## Version History
 
+#### 1.5.0
+
+* Swap levels 16-21 with 22-27 to introduce toroidal topology before cement mode.
+* Custom level mode available in the sidebar.
+    * Allows you to turn off cement mode.
+    * Allows extreme sized levels.
+    * Allows toroidal topology without a starter island.
+    * Does not allow toroidal topology with odd sizes.
+* Level select available in the side bar to revisit previous levels.
+
 #### 1.4.0
 
 2023-Feb-11

--- a/public/a.ts
+++ b/public/a.ts
@@ -10,6 +10,14 @@ const tile_set_select = document.getElementById("tileSetSelect") as HTMLSelectEl
 const level_number_span = document.getElementById("level_number_span") as HTMLSpanElement;
 const level_down_button = document.getElementById("level_down_button") as HTMLButtonElement;
 const level_up_button = document.getElementById("level_up_button") as HTMLButtonElement;
+const show_custom_level_button = document.getElementById("show_custom_level_button") as HTMLButtonElement;
+const level_settings_div = document.getElementById("level_settings_div") as HTMLDivElement;
+const custom_shape_select = document.getElementById("custom_shape_select") as HTMLSelectElement;
+const custom_toroidal_checkbox = document.getElementById("custom_toroidal_checkbox") as HTMLInputElement;
+const custom_rough_checkbox = document.getElementById("custom_rough_checkbox") as HTMLInputElement;
+const custom_cement_mode_checkbox = document.getElementById("custom_cement_mode_checkbox") as HTMLInputElement;
+const custom_width_spinner = document.getElementById("custom_width_spinner") as HTMLInputElement;
+const custom_height_spinner = document.getElementById("custom_height_spinner") as HTMLInputElement;
 
 const pi = Math.PI;
 const sqrt3 = Math.sqrt(3);
@@ -1438,6 +1446,19 @@ function renderLevelInfoInSidebar() {
     level_number_span.innerText = level_number.toString();
     level_up_button.disabled = false;
   }
+  custom_shape_select.value = Shape[level.shape];
+  custom_toroidal_checkbox.checked = level.toroidal;
+  custom_rough_checkbox.checked = level.rough;
+  custom_cement_mode_checkbox.checked = level.cement_mode;
+  let width = level.tiles_per_row;
+  let height = level.tiles_per_column;
+  if (!level.toroidal) {
+    // Present the size without the border of padding.
+    width -= 2;
+    height -= 2;
+  }
+  custom_width_spinner.value = width as unknown as string;
+  custom_height_spinner.value = height as unknown as string;
 }
 
 function doFadeOut() {
@@ -1769,6 +1790,10 @@ level_down_button.addEventListener("click", function() {
 });
 level_up_button.addEventListener("click", function() {
   loadNewLevel({delta: 1});
+});
+show_custom_level_button.addEventListener("click", function() {
+  level_settings_div.classList.toggle("hidden");
+  show_custom_level_button.innerText = ( level_settings_div.classList.contains("hidden") ? ">" : "v" )+ " Custom Level";
 });
 
 function getSaveObject(): {[key:string]:any} {

--- a/public/a.ts
+++ b/public/a.ts
@@ -7,6 +7,9 @@ const retry_button = document.getElementById("retryButton") as HTMLButtonElement
 const reset_button = document.getElementById("resetButton") as HTMLButtonElement;
 const tile_set_div = document.getElementById("tileSetDiv") as HTMLDivElement;
 const tile_set_select = document.getElementById("tileSetSelect") as HTMLSelectElement;
+const level_number_span = document.getElementById("level_number_span") as HTMLSpanElement;
+const level_down_button = document.getElementById("level_down_button") as HTMLButtonElement;
+const level_up_button = document.getElementById("level_up_button") as HTMLButtonElement;
 
 const pi = Math.PI;
 const sqrt3 = Math.sqrt(3);
@@ -1422,8 +1425,18 @@ function setGameState(new_state: GameState) {
   asdf_alpha = 1.0;
   game_state = new_state;
 
-  if (level_number > 27) {
+  renderLevelInfoInSidebar();
+}
+
+function renderLevelInfoInSidebar() {
+  level_down_button.disabled = level_number <= 1;
+  if (level_number >= last_level_number) {
+    level_number_span.innerText = last_level_number + "+";
     tile_set_div.classList.remove("hidden");
+    level_up_button.disabled = true;
+  } else {
+    level_number_span.innerText = level_number.toString();
+    level_up_button.disabled = false;
   }
 }
 
@@ -1524,6 +1537,8 @@ function loadNewLevel(opts?: {delta?: number, shuffle_tiles?: boolean}) {
 }
 function getLevelForCurrentLevelNumber(shuffle_tiles: boolean): Level {
   if (level_number < 1) level_number = 1;
+  if (level_number > last_level_number) level_number = last_level_number;
+  if (!Number.isInteger(level_number)) level_number = 1;
 
   switch (level_number) {
     case 1:
@@ -1601,15 +1616,17 @@ function getLevelForCurrentLevelNumber(shuffle_tiles: boolean): Level {
         return {size:[6, 6], shape: Shape.Hexagon, colors: ColorRules.TwoSeparate, toroidal: true, rough: true};
       case 27:
         return {size:[6, 6], shape: Shape.Hexagon, colors: ColorRules.Single, toroidal: true, rough: true};
-      default:
+      case last_level_number:
         // the final challenge
         return {size:[6, 6], shape: Shape.Hexagon, colors: ColorRules.Single, cement_mode: true, toroidal: true, rough: true, perfectable: true};
+      default: throw new AssertionFailure();
     }
   }();
 
   params.shuffle_tiles = shuffle_tiles;
   return generateLevel(params);
 }
+const last_level_number = 28;
 
 function oneColor(values: number[]): number[][] {
   let result = [];
@@ -1745,6 +1762,13 @@ tile_set_select.addEventListener("input", function() {
   tile_set = TileSet[tile_set_select.value as keyof typeof TileSet];
   renderEverything();
   save();
+});
+
+level_down_button.addEventListener("click", function() {
+  loadNewLevel({delta: -1});
+});
+level_up_button.addEventListener("click", function() {
+  loadNewLevel({delta: 1});
 });
 
 function getSaveObject(): {[key:string]:any} {

--- a/public/a.ts
+++ b/public/a.ts
@@ -14,11 +14,17 @@ const level_up_button = document.getElementById("level_up_button") as HTMLButton
 const show_custom_level_button = document.getElementById("show_custom_level_button") as HTMLButtonElement;
 const level_settings_div = document.getElementById("level_settings_div") as HTMLDivElement;
 const custom_colors_select = document.getElementById("custom_colors_select") as HTMLSelectElement;
+const custom_colors_div = document.getElementById("custom_colors_div") as HTMLDivElement;
+const custom_color_two_overlap_option = document.getElementById("custom_color_two_overlap_option") as HTMLOptionElement;
 const custom_shape_select = document.getElementById("custom_shape_select") as HTMLSelectElement;
+const custom_shape_div = document.getElementById("custom_shape_div") as HTMLDivElement;
 const custom_toroidal_checkbox = document.getElementById("custom_toroidal_checkbox") as HTMLInputElement;
+const custom_toroidal_div = document.getElementById("custom_toroidal_div") as HTMLDivElement;
 const custom_rough_checkbox = document.getElementById("custom_rough_checkbox") as HTMLInputElement;
+const custom_rough_div = document.getElementById("custom_rough_div") as HTMLDivElement;
 const rough_label_span = document.getElementById("rough_label_span") as HTMLSpanElement;
 const custom_cement_mode_checkbox = document.getElementById("custom_cement_mode_checkbox") as HTMLInputElement;
+const custom_cement_mode_div = document.getElementById("custom_cement_mode_div") as HTMLDivElement;
 const custom_width_spinner = document.getElementById("custom_width_spinner") as HTMLInputElement;
 const custom_height_spinner = document.getElementById("custom_height_spinner") as HTMLInputElement;
 
@@ -1465,10 +1471,16 @@ function renderLevelInfoInSidebar() {
     level_up_button.disabled = false;
   }
   custom_colors_select.value = ColorRules[level.colors];
+  setElementVisible(custom_colors_div, unlocked_level_number >= 10);
+  setElementVisible(custom_color_two_overlap_option, unlocked_level_number >= 14);
   custom_shape_select.value = Shape[level.shape];
+  setElementVisible(custom_shape_div, unlocked_level_number >= 6);
   custom_toroidal_checkbox.checked = level.toroidal;
+  setElementVisible(custom_toroidal_div, unlocked_level_number >= 16);
   custom_rough_checkbox.checked = level.rough;
+  setElementVisible(custom_rough_div, unlocked_level_number >= 11);
   custom_cement_mode_checkbox.checked = level.cement_mode;
+  setElementVisible(custom_cement_mode_div, unlocked_level_number >= 22);
   let width = level.tiles_per_row;
   let height = level.tiles_per_column;
   if (!level.toroidal) {
@@ -1844,6 +1856,14 @@ function clamp(min: number, x: number, max: number): number {
   return x;
 }
 
+function setElementVisible(element: HTMLElement, isVisible: boolean) {
+  if (isVisible) {
+    element.classList.remove("hidden");
+  } else {
+    element.classList.add("hidden");
+  }
+}
+
 retry_button.addEventListener("click", function() {
   loadNewLevel();
   hideSidebar();
@@ -1917,15 +1937,15 @@ function save() {
     // Version 1.5+
     unlocked_level_number = save_data.unlocked_level_number;
   } else {
-    // Version 1.5, swapped levels 16-21 with levels 22-27.
-    // This swapped the introduction of toroidal topology and cement mode
-    // to make cement mode show up later.
+    // The upgrade to version 1.5 swapped levels 16-21 with levels 22-27
+    // to introduce toroidal topology before cement mode.
     if (16 <= level_number && level_number <= 27) {
-      // Sry fam.
+      // Sorry buddy.
       alert(
         `New version of Loops released! Levels 16-27 have been updated, ` +
         `so your progress through level ${level_number} unfortunately cannot be loaded. :( ` +
-        `You've been set back to level 16. Please enjoy the new sequence of levels! :)`
+        `You've been set back to level 16. Please enjoy the new sequence of levels! ` +
+        `(And don't forget to check the sidebar for cool new stuff!) :)`
       );
       level_number = 16;
       delete save_data.level;

--- a/public/index.html
+++ b/public/index.html
@@ -65,6 +65,9 @@
       #sidebar > div {
         margin: 12px 0px;
       }
+      #level_settings_div {
+        padding-left: 12px;
+      }
 
       input[type=number] {
         width: 2em;
@@ -92,14 +95,19 @@
       </div>
       <button id="show_custom_level_button">&gt; Custom Level</button>
       <div id="level_settings_div" class="hidden">
+        <div>Colors: <select id="custom_colors_select">
+          <option value="Single">Single</option>
+          <option value="TwoSeparate">Double</option>
+          <option value="TwoOverlap">Overlap</option>
+        </select></div>
         <div>Shape: <select id="custom_shape_select">
           <option value="Square">Square</option>
           <option value="Hexagon">Hexagon</option>
         </select></div>
         <div><label><input type="checkbox" id="custom_toroidal_checkbox"> Wrapping</label></div>
-        <div><label><input type="checkbox" id="custom_rough_checkbox"> Rough Edges</label></div>
+        <div><label><input type="checkbox" id="custom_rough_checkbox"> <span id="rough_label_span">Rough Edges</span></label></div>
         <div><label><input type="checkbox" id="custom_cement_mode_checkbox"> Lock Tiles</label></div>
-        <div>Size: <input type="number" id="custom_width_spinner">x<input type="number" id="custom_height_spinner"></div>
+        <div>Size: <input type="number" min=1 max=20 id="custom_width_spinner">x<input type="number" min=1 max=20 id="custom_height_spinner"></div>
       </div>
       <div id="tileSetDiv" class="hidden">
         Tile Set:

--- a/public/index.html
+++ b/public/index.html
@@ -95,18 +95,18 @@
       </div>
       <button id="show_custom_level_button">&gt; Custom Level</button>
       <div id="level_settings_div" class="hidden">
-        <div>Colors: <select id="custom_colors_select">
+        <div id="custom_colors_div">Colors: <select id="custom_colors_select">
           <option value="Single">Single</option>
           <option value="TwoSeparate">Double</option>
-          <option value="TwoOverlap">Overlap</option>
+          <option id="custom_color_two_overlap_option" value="TwoOverlap">Overlap</option>
         </select></div>
-        <div>Shape: <select id="custom_shape_select">
+        <div id="custom_shape_div">Shape: <select id="custom_shape_select">
           <option value="Square">Square</option>
           <option value="Hexagon">Hexagon</option>
         </select></div>
-        <div><label><input type="checkbox" id="custom_toroidal_checkbox"> Wrapping</label></div>
-        <div><label><input type="checkbox" id="custom_rough_checkbox"> <span id="rough_label_span">Rough Edges</span></label></div>
-        <div><label><input type="checkbox" id="custom_cement_mode_checkbox"> Lock Tiles</label></div>
+        <div id="custom_toroidal_div"><label><input type="checkbox" id="custom_toroidal_checkbox"> Wrapping</label></div>
+        <div id="custom_rough_div"><label><input type="checkbox" id="custom_rough_checkbox"> <span id="rough_label_span">Rough Edges</span></label></div>
+        <div id="custom_cement_mode_div"><label><input type="checkbox" id="custom_cement_mode_checkbox"> Lock Tiles</label></div>
         <div>Size: <input type="number" min=1 max=20 id="custom_width_spinner">x<input type="number" min=1 max=20 id="custom_height_spinner"></div>
       </div>
       <div id="tileSetDiv" class="hidden">

--- a/public/index.html
+++ b/public/index.html
@@ -51,7 +51,7 @@
         top: 0px;
         left: -275px;
         width: 275px;
-        padding: 20px 0px;
+        padding: 50px 0px 0px 12px;
         height: 100%;
         background-color: #f6f6f6;
         color: #343838;
@@ -61,6 +61,10 @@
       }
       /* slide in */
       #sidebar.active { left: 0px; }
+
+      #sidebar > div {
+        margin: 12px 0px;
+      }
 
       .hidden {
         display: none !important;
@@ -76,11 +80,12 @@
       <div id="bottom"></div>
     </div>
     <div id="sidebar">
-      <div>&nbsp;</div>
       <div><button id="retryButton">Retry Level</button></div>
-      <div>&nbsp;</div>
-      <div><button id="resetButton">Erase Progress</button></div>
-      <div>&nbsp;</div>
+      <div>Level:
+        <button id="level_down_button">&lt;</button>
+        <span id="level_number_span">1</span>
+        <button id="level_up_button">&gt;</button>
+      </div>
       <div id="tileSetDiv" class="hidden">
         Tile Set:
         <select id="tileSetSelect">
@@ -89,12 +94,15 @@
           <option value="Iso">Iso</option>
           <option value="Chaos">Chaos</option>
         </select>
-        <div>&nbsp;</div>
       </div>
       <div>&nbsp;</div>
-      <div>Version 1.4.0</div>
-      <div>* <a href="https://github.com/thejoshwolfe/loops/blob/master/README.md">what's new</a></div>
-      <div>* <a href="https://github.com/thejoshwolfe/loops">source code</a></div>
+      <div><button id="resetButton">Erase Progress</button></div>
+      <div>Version 1.4.0
+        <ul>
+          <li>* <a href="https://github.com/thejoshwolfe/loops/blob/master/README.md">what's new</a></li>
+          <li>* <a href="https://github.com/thejoshwolfe/loops">source code</a></li>
+        </ul>
+      </div>
     </div>
 
     <script src="a.js"></script>

--- a/public/index.html
+++ b/public/index.html
@@ -66,6 +66,10 @@
         margin: 12px 0px;
       }
 
+      input[type=number] {
+        width: 2em;
+      }
+
       .hidden {
         display: none !important;
       }
@@ -85,6 +89,17 @@
         <button id="level_down_button">&lt;</button>
         <span id="level_number_span">1</span>
         <button id="level_up_button">&gt;</button>
+      </div>
+      <button id="show_custom_level_button">&gt; Custom Level</button>
+      <div id="level_settings_div" class="hidden">
+        <div>Shape: <select id="custom_shape_select">
+          <option value="Square">Square</option>
+          <option value="Hexagon">Hexagon</option>
+        </select></div>
+        <div><label><input type="checkbox" id="custom_toroidal_checkbox"> Wrapping</label></div>
+        <div><label><input type="checkbox" id="custom_rough_checkbox"> Rough Edges</label></div>
+        <div><label><input type="checkbox" id="custom_cement_mode_checkbox"> Lock Tiles</label></div>
+        <div>Size: <input type="number" id="custom_width_spinner">x<input type="number" id="custom_height_spinner"></div>
       </div>
       <div id="tileSetDiv" class="hidden">
         Tile Set:


### PR DESCRIPTION
* Swap levels 16-21 with 22-27 to introduce toroidal topology before locking tiles.
    * If your current level was in this range, you'll be reset back to level 16.
* Custom level mode available in the sidebar.
    * Allows you to turn off locking tiles.
    * Allows extreme sized levels.
    * Allows toroidal topology without a starter island (hard mode!).
    * (Does not allow toroidal topology with odd sizes. It's complicated.)
    * Settings are unlocked as you encounter them in the linear level progression.
    * Resume linear levels by collapsing the `Custom Level` settings.
* Level select available in the side bar to revisit previous levels.
